### PR TITLE
fix: correct typo in publishedAt (not working on MacOS/iOS)

### DIFF
--- a/posts/blog/storybook-vite.mdx
+++ b/posts/blog/storybook-vite.mdx
@@ -1,7 +1,7 @@
 ---
 title: "How To Setup Storybook with Vite + Example"
 summary: "An overwiew of how I set up Storybook in a Vite project, all challenges I faced, and the solutions I found."
-publishedAt: "2022-08-3"
+publishedAt: "2022-08-03"
 tags:
   - Storybook
   - Vite


### PR DESCRIPTION
```mdx
---
title: "How To Setup Storybook with Vite + Example"
summary: "An overview of how I set up Storybook in a Vite project, all challenges I faced, and the solutions I found."
publishedAt: "2022-08-03"
tags:
  - Storybook
  - Vite
---
```

- `publishedAt` was changed from `"2022-08-3"` to `"2022-08-03"`, apparently the `new Date` function was parsing it correctly on Windows, so I didn't expect that MacOS/iOS browsers could have caused troubles.